### PR TITLE
Don't show border for 0 percent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,8 @@ export default class PercentageCircle extends Component {
       halfCircle2Styles,
     } = this.computeDerivedState()
 
+    const percent = Math.max(Math.min(100, this.props.percent), 0);
+
     return (
       <View
         style={[
@@ -161,8 +163,10 @@ export default class PercentageCircle extends Component {
           },
         ]}
       >
-        {this.renderHalfCircle(halfCircle1Degree)}
-        {this.renderHalfCircle(halfCircle2Degree, halfCircle2Styles)}
+        {percent ? this.renderHalfCircle(halfCircle1Degree) : null}
+        {percent
+          ? this.renderHalfCircle(halfCircle2Degree, halfCircle2Styles)
+          : null}
         {this.renderInnerCircle()}
       </View>
     )


### PR DESCRIPTION
Solves a graphical glitch where setting "color" to "white" on a "black" background and "bgColor" and "shadowColor" also set to "black" creates a very light but disturbing white border on the left, when percent is 0.  Obviously the calls to "renderHalfCircle" provoke that. So if percent is 0, just don't call "renderHalfCircle" as it is unnecessary anyway